### PR TITLE
Explicitly support Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Education",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Monitoring",


### PR DESCRIPTION
Be explicit about supporting Python 3.8 in `pyproject.toml` -> should propagate to PyPI and badges. We are testing on 3.6, 3.7, and 3.8 in CircleCI