### PR TITLE
Switch to new, maintained fork of bumpversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,6 @@ requires           = [
 
 
 [tool.flit.metadata.requires-extra]
-dev                = ["black", "bumpversion", "flake8", "flit", "mypy"]
+dev                = ["black", "bump2version", "flake8", "flit", "mypy"]
 test               = ["pytest", "pytest-cov", "tox"]
 


### PR DESCRIPTION
The original [bumpversion](https://pypi.org/project/bumpversion/) has not been updated since 2015. After running into a [bug in the Windows version](https://github.com/c4urself/bump2version/issues/11), I found [bump2version](https://pypi.org/project/bump2version/) which is a fork (and drop-in replacement) that is actively maintained.