### PR TITLE
Refactor split init

### DIFF
--- a/codetiming/__init__.py
+++ b/codetiming/__init__.py
@@ -4,85 +4,25 @@ You can use `codetiming.Timer` in several different ways:
 
 1. As a **class**:
 
-    ```python
     t = Timer(name="class")
     t.start()
     # Do something
     t.stop()
-    ```
 
 2. As a **context manager**:
 
-    ```python
     with Timer(name="context manager"):
         # Do something
-    ```
 
 3. As a **decorator**:
 
-    ```python
     @Timer(name="decorator")
     def stuff():
         # Do something
-    ```
 """
 
-from contextlib import ContextDecorator
-from dataclasses import dataclass, field
-import time
-from typing import Any, Callable, ClassVar, Dict, Optional
+# Import Timer for cleaner namespace
+from codetiming._timer import Timer, TimerError  # noqa
 
+# Versioning is handled by bump2version
 __version__ = "0.1.1"
-
-
-class TimerError(Exception):
-    """A custom exception used to report errors in use of Timer class"""
-
-
-@dataclass
-class Timer(ContextDecorator):
-    """Time your code using a class, context manager, or decorator"""
-
-    timers: ClassVar[Dict[str, float]] = dict()
-    name: Optional[str] = None
-    text: str = "Elapsed time: {:0.4f} seconds"
-    logger: Optional[Callable[[str], None]] = print
-    _start_time: Optional[float] = field(default=None, init=False, repr=False)
-
-    def __post_init__(self) -> None:
-        """Initialization: add timer to dict of timers"""
-        if self.name:
-            self.timers.setdefault(self.name, 0)
-
-    def start(self) -> None:
-        """Start a new timer"""
-        if self._start_time is not None:
-            raise TimerError(f"Timer is running. Use .stop() to stop it")
-
-        self._start_time = time.perf_counter()
-
-    def stop(self) -> float:
-        """Stop the timer, and report the elapsed time"""
-        if self._start_time is None:
-            raise TimerError(f"Timer is not running. Use .start() to start it")
-
-        # Calculate elapsed time
-        elapsed_time = time.perf_counter() - self._start_time
-        self._start_time = None
-
-        # Report elapsed time
-        if self.logger:
-            self.logger(self.text.format(elapsed_time))
-        if self.name:
-            self.timers[self.name] += elapsed_time
-
-        return elapsed_time
-
-    def __enter__(self) -> "Timer":
-        """Start a new timer as a context manager"""
-        self.start()
-        return self
-
-    def __exit__(self, *exc_info: Any) -> None:
-        """Stop the context manager timer"""
-        self.stop()

--- a/codetiming/_timer.py
+++ b/codetiming/_timer.py
@@ -1,0 +1,64 @@
+"""Definition of Timer
+
+See help(codetiming) for quick instructions, and
+https://pypi.org/project/codetiming/ for more details 
+"""
+
+# Standard library imports
+from contextlib import ContextDecorator
+from dataclasses import dataclass, field
+import time
+from typing import Any, Callable, ClassVar, Dict, Optional
+
+
+class TimerError(Exception):
+    """A custom exception used to report errors in use of Timer class"""
+
+
+@dataclass
+class Timer(ContextDecorator):
+    """Time your code using a class, context manager, or decorator"""
+
+    timers: ClassVar[Dict[str, float]] = dict()
+    name: Optional[str] = None
+    text: str = "Elapsed time: {:0.4f} seconds"
+    logger: Optional[Callable[[str], None]] = print
+    _start_time: Optional[float] = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Initialization: add timer to dict of timers"""
+        if self.name:
+            self.timers.setdefault(self.name, 0)
+
+    def start(self) -> None:
+        """Start a new timer"""
+        if self._start_time is not None:
+            raise TimerError(f"Timer is running. Use .stop() to stop it")
+
+        self._start_time = time.perf_counter()
+
+    def stop(self) -> float:
+        """Stop the timer, and report the elapsed time"""
+        if self._start_time is None:
+            raise TimerError(f"Timer is not running. Use .start() to start it")
+
+        # Calculate elapsed time
+        elapsed_time = time.perf_counter() - self._start_time
+        self._start_time = None
+
+        # Report elapsed time
+        if self.logger:
+            self.logger(self.text.format(elapsed_time))
+        if self.name:
+            self.timers[self.name] += elapsed_time
+
+        return elapsed_time
+
+    def __enter__(self) -> "Timer":
+        """Start a new timer as a context manager"""
+        self.start()
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        """Stop the context manager timer"""
+        self.stop()

--- a/codetiming/_timer.py
+++ b/codetiming/_timer.py
@@ -1,7 +1,7 @@
 """Definition of Timer
 
 See help(codetiming) for quick instructions, and
-https://pypi.org/project/codetiming/ for more details 
+https://pypi.org/project/codetiming/ for more details.
 """
 
 # Standard library imports


### PR DESCRIPTION
Split `__init__.py` into two files.

Instead of having all code, we split it into two files. This has a couple of advantages:

- It keeps the `codetiming` namespace clean
- It separates code from the setup/metadata of the module