### PR TITLE
Add the ability to compare a timer to another value.

### DIFF
--- a/codetiming/_timer.py
+++ b/codetiming/_timer.py
@@ -25,7 +25,7 @@ class Timer(ContextDecorator):
     text: str = "Elapsed time: {:0.4f} seconds"
     logger: Optional[Callable[[str], None]] = print
     _start_time: Optional[float] = field(default=None, init=False, repr=False)
-    _value: Optional[float] = field(default=nan, init=False, repr=False)
+    last: float = field(default=nan, init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Initialization: add timer to dict of timers"""
@@ -45,17 +45,16 @@ class Timer(ContextDecorator):
             raise TimerError(f"Timer is not running. Use .start() to start it")
 
         # Calculate elapsed time
-        elapsed_time = time.perf_counter() - self._start_time
-        self._value = elapsed_time
+        self.last = time.perf_counter() - self._start_time
         self._start_time = None
 
         # Report elapsed time
         if self.logger:
-            self.logger(self.text.format(elapsed_time))
+            self.logger(self.text.format(self.last))
         if self.name:
-            self.timers[self.name] += elapsed_time
+            self.timers[self.name] += self.last
 
-        return elapsed_time
+        return self.last
 
     def __enter__(self) -> "Timer":
         """Start a new timer as a context manager"""
@@ -65,18 +64,3 @@ class Timer(ContextDecorator):
     def __exit__(self, *exc_info: Any) -> None:
         """Stop the context manager timer"""
         self.stop()
-
-    def __eq__(self, other):
-        return self._value == other
-
-    def __lt__(self, other):
-        return self._value < other
-
-    def __le__(self, other):
-        return self._value <= other
-
-    def __gt__(self, other):
-        return self._value > other
-
-    def __ge__(self, other):
-        return self._value >= other

--- a/codetiming/_timer.py
+++ b/codetiming/_timer.py
@@ -7,6 +7,7 @@ https://pypi.org/project/codetiming/ for more details.
 # Standard library imports
 from contextlib import ContextDecorator
 from dataclasses import dataclass, field
+from math import nan
 import time
 from typing import Any, Callable, ClassVar, Dict, Optional
 
@@ -24,6 +25,7 @@ class Timer(ContextDecorator):
     text: str = "Elapsed time: {:0.4f} seconds"
     logger: Optional[Callable[[str], None]] = print
     _start_time: Optional[float] = field(default=None, init=False, repr=False)
+    _value: Optional[float] = field(default=nan, init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Initialization: add timer to dict of timers"""
@@ -44,6 +46,7 @@ class Timer(ContextDecorator):
 
         # Calculate elapsed time
         elapsed_time = time.perf_counter() - self._start_time
+        self._value = elapsed_time
         self._start_time = None
 
         # Report elapsed time
@@ -62,3 +65,18 @@ class Timer(ContextDecorator):
     def __exit__(self, *exc_info: Any) -> None:
         """Stop the context manager timer"""
         self.stop()
+
+    def __eq__(self, other):
+        return self._value == other
+
+    def __lt__(self, other):
+        return self._value < other
+
+    def __le__(self, other):
+        return self._value <= other
+
+    def __gt__(self, other):
+        return self._value > other
+
+    def __ge__(self, other):
+        return self._value >= other

--- a/codetiming/_timer.py
+++ b/codetiming/_timer.py
@@ -5,10 +5,10 @@ https://pypi.org/project/codetiming/ for more details.
 """
 
 # Standard library imports
+import time
 from contextlib import ContextDecorator
 from dataclasses import dataclass, field
 from math import nan
-import time
 from typing import Any, Callable, ClassVar, Dict, Optional
 
 

--- a/tests/test_codetiming.py
+++ b/tests/test_codetiming.py
@@ -168,23 +168,11 @@ def test_error_if_restarting_running_timer():
         t.start()
 
 
-def test_timer_compares_to_numbers():
+def test_timer_sets_last():
     t = Timer()
+    assert isnan(t.last)
     t.start()
     time.sleep(0.1)
     t.stop()
 
-    assert t > 0.1 and t >= 0.1
-    assert t < 1 and t <= 1
-
-
-def test_timer_compares_false_before_starting():
-    t = Timer()
-
-    assert isnan(t._value)
-
-    assert not t == 0
-    assert not t <= 1
-    assert not t < 1
-    assert not t >= 0
-    assert not t > 0
+    assert 0.1 < t.last < 1

--- a/tests/test_codetiming.py
+++ b/tests/test_codetiming.py
@@ -10,6 +10,8 @@ import pytest
 
 # Codetiming imports
 from codetiming import Timer, TimerError
+import time
+from math import isnan
 
 
 #
@@ -164,3 +166,25 @@ def test_error_if_restarting_running_timer():
     t.start()
     with pytest.raises(TimerError):
         t.start()
+
+
+def test_timer_compares_to_numbers():
+    t = Timer()
+    t.start()
+    time.sleep(0.1)
+    t.stop()
+
+    assert t > 0.1 and t >= 0.1
+    assert t < 1 and t <= 1
+
+
+def test_timer_compares_false_before_starting():
+    t = Timer()
+
+    assert isnan(t._value)
+
+    assert not t == 0
+    assert not t <= 1
+    assert not t < 1
+    assert not t >= 0
+    assert not t > 0

--- a/tests/test_codetiming.py
+++ b/tests/test_codetiming.py
@@ -174,4 +174,4 @@ def test_timer_sets_last():
     time.sleep(0.1)
     t.stop()
 
-    assert 0.1 < t.last < 1
+    assert 0.1 <= t.last

--- a/tests/test_codetiming.py
+++ b/tests/test_codetiming.py
@@ -4,15 +4,14 @@ Based on the Pytest test runner
 """
 # Standard library imports
 import re
+import time
+from math import isnan
 
 # Third party imports
 import pytest
 
 # Codetiming imports
 from codetiming import Timer, TimerError
-import time
-from math import isnan
-
 
 #
 # Test functions


### PR DESCRIPTION
This allows checking whether the last measured time is greater
or less than some 'reference' value.

- `Timer` class now has a reference to the last-measured value; initially this is `nan`
- comparison operators are defined for `Timer` objects.

This is useful if you want to display messages if some operation
has taken too long in the past.

For example:

```python
from codetiming import Timer
import time

image_display_timer = Timer()

def _display_hold_message():
    print('loading image...')

@image_display_timer
def display_image():
    if image_display_timer > 0.2:
        _display_hold_message()
    time.sleep(0.5)
    print('here is your image')
```

This results in a message being displayed when the function is used for the
second time:

```python
>>> display_image()
here is your image
Elapsed time: 0.5051 seconds

>>> display_image()
loading image...
here is your image
Elapsed time: 0.5052 seconds
```
