### PR TITLE
Add tests and explicit support for Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,18 @@
 version: 2
 
 shared: &shared
-    working_directory: ~/circleci-codetiming
-    steps:
-      - checkout
-      - run:
-          name: Install
-          command: |
-            python -m pip install flit --user
-            python -m flit install --deps=develop
-      - run:
-          name: Test
-          command: |
-            python -m tox --recreate
+  working_directory: ~/circleci-codetiming
+  steps:
+    - checkout
+    - run:
+        name: Install
+        command: |
+          python -m pip install flit --user
+          python -m flit install --deps=develop
+    - run:
+        name: Test
+        command: |
+          python -m tox --recreate
 
 jobs:
   "test-py36":
@@ -28,8 +28,12 @@ jobs:
   "test-py38":
     <<: *shared
     docker:
-      - image: circleci/python:3.8-rc
+      - image: circleci/python:3.8
 
+  "test-py39":
+    <<: *shared
+    docker:
+      - image: circleci/python:3.9-rc
 
 workflows:
   version: 2
@@ -39,3 +43,4 @@ workflows:
       - "test-py36"
       - "test-py37"
       - "test-py38"
+      - "test-py39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Education",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Monitoring",


### PR DESCRIPTION
Do tests on the latest release candidate of Python 3.9. The PR also adds explicit support for 3.9 on the package description on PyPI.