### PR TITLE
Don't run Mypy tests on Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,10 @@ jobs:
     docker:
       - image: circleci/python:3.8
 
-  "test-py39":
+  "test-py39-no-mypy":
     <<: *shared
+    environment:
+      TOX_SKIP_ENV: mypy
     docker:
       - image: circleci/python:3.9-rc
 
@@ -43,4 +45,4 @@ workflows:
       - "test-py36"
       - "test-py37"
       - "test-py38"
-      - "test-py39"
+      - "test-py39-no-mypy"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog1.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
 ## [Unreleased]


### PR DESCRIPTION
Mypy testing doesn't seem to be supported yet on Python 3.9, so we disable it for now.