### PR TITLE
Add public API for type checkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `__all__` to let type checkers know what is part of the public API. (by [@alkatar21](https://github.com/alkatar21) in [#46])
+
 ## [1.3.1] - 2022-10-06
 
 ### Added
@@ -73,3 +77,4 @@ Initial version of `codetiming`. Version 1.0.0 corresponds to the code in the tu
 [#34]: https://github.com/realpython/codetiming/pull/34
 [#35]: https://github.com/realpython/codetiming/pull/35
 [#38]: https://github.com/realpython/codetiming/pull/38
+[#46]: https://github.com/realpython/codetiming/pull/46

--- a/codetiming/__init__.py
+++ b/codetiming/__init__.py
@@ -22,7 +22,10 @@ You can use `codetiming.Timer` in several different ways:
 """
 
 # Codetiming imports
-from codetiming._timer import Timer, TimerError  # noqa
+from codetiming._timer import Timer, TimerError
+
+# Use __all__ to let type checkers know what is part of the public API.
+__all__ = ["Timer", "TimerError"]
 
 # Versioning is handled by bump2version
 __version__ = "1.3.1"


### PR DESCRIPTION
Closes  #44

Add `__all__` to `__init__.py` for type checkers and the changelog entry.