### PR TITLE
Add framework for timer startup log statement

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,9 +10,9 @@
 
 ## Contributors
 
-- [Jan Freyberg](https://github.com/janfreyberg)
 - [Alkatar21](https://github.com/alkatar21)
 - [D.C. Hess](https://github.com/dchess)
+- [Jan Freyberg](https://github.com/janfreyberg)
 - [Mischa Lisovyi](https://github.com/mlisovyi)
 - [Matthew Price](https://github.com/pricemg)
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,5 +14,6 @@
 - [Alkatar21](https://github.com/alkatar21)
 - [D.C. Hess](https://github.com/dchess)
 - [Mischa Lisovyi](https://github.com/mlisovyi)
+- [Matthew Price](https://github.com/pricemg)
 
 See the [changelog](https://github.com/realpython/codetiming/blob/master/CHANGELOG.md) for more details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- `inital_text` attribute to `Timer` class, which when present will use logger
-  to log that timer has been started (by [Matthew Price](https://github.com/pricemg) in [#47])
+- `inital_text` parameter which, when present, will use logger to log that timer has been started (by [Matthew Price](https://github.com/pricemg) in [#47])
 
 ## [1.3.2] - 2022-10-07
 
@@ -45,7 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- `Timer.timers` changed from regular to `dict` to a custom dictionary supporting basic statistics for named timers ([#23]).
+- `Timer.timers` changed from regular `dict` to a custom dictionary supporting basic statistics for named timers ([#23]).
 
 
 ## [1.1.0] - 2020-01-15
@@ -86,3 +85,4 @@ Initial version of `codetiming`. Version 1.0.0 corresponds to the code in the tu
 [#35]: https://github.com/realpython/codetiming/pull/35
 [#38]: https://github.com/realpython/codetiming/pull/38
 [#46]: https://github.com/realpython/codetiming/pull/46
+[#47]: https://github.com/realpython/codetiming/pull/47

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `inital_text` attribute to `Timer` class, which when present will use logger
+  to log that timer has been started (by [Matthew Price](https://github.com/pricemg) in [#47])
+
 ## [1.3.2] - 2022-10-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ You can use `codetiming.Timer` in several different ways:
 `Timer` accepts the following arguments when it's created. All arguments are optional:
 
 - **`name`:** An optional name for your timer
-- **`text`:** The text shown when your timer ends. It should contain a `{}` placeholder that will be filled by the elapsed time in seconds (default: `"Elapsed time: {:.4f} seconds"`)
+- **`text`:** The text that's shown when your timer ends. It should contain a `{}` placeholder that will be filled by the elapsed time in seconds (default: `"Elapsed time: {:.4f} seconds"`)
+- **`initial_text`:** Show text when your timer starts. You may provide the string to be logged or `True` to show the default text `"Timer {name} started"` (default: `False`)
 - **`logger`:** A function/callable that takes a string argument and will report the elapsed time when the logger is stopped (default: `print()`)
 
 You can turn off explicit reporting of the elapsed time by setting `logger=None`.
@@ -81,12 +82,20 @@ t = Timer(text=lambda secs: f"{secs / 86400:.0f} days")
 
 This allows you to use third-party libraries like [`humanfriendly`](https://pypi.org/project/humanfriendly/) to do the text formatting:
 
-```
+```python
 from humanfriendly import format_timespan
 
 t1 = Timer(text=format_timespan)
 t2 = Timer(text=lambda secs: f"Elapsed time: {format_timespan(secs)}")
 ```
+
+You may include a text that should be logged when the timer starts by setting `initial_text`:
+
+```python
+t = Timer(initial_text="And so it begins ...")
+```
+
+You can also set `initial_text=True` to use a default initial text.
 
 
 ## Capturing the Elapsed Time
@@ -109,7 +118,7 @@ elapsed_time = t.last
 
 Named timers are made available in the class dictionary `Timer.timers`. The elapsed time will accumulate if the same name or same timer is used several times. Consider the following example:
 
-```python
+```pycon
 >>> import logging
 >>> from codetiming import Timer
 
@@ -133,7 +142,7 @@ The example shows how you can redirect the timer output to the logging module. N
 
 You can also get simple statistics about your named timers. Continuing from the example above:
 
-```python
+```pycon
 >>> Timer.timers.max("example")
 3.5836678670002584
 

--- a/codetiming/_timer.py
+++ b/codetiming/_timer.py
@@ -26,19 +26,22 @@ class Timer(ContextDecorator):
     timers: ClassVar[Timers] = Timers()
     _start_time: Optional[float] = field(default=None, init=False, repr=False)
     name: Optional[str] = None
+    initial_text: Optional[Union[bool, str]] = False
     text: Union[str, Callable[[float], str]] = "Elapsed time: {:0.4f} seconds"
     logger: Optional[Callable[[str], None]] = print
     last: float = field(default=math.nan, init=False, repr=False)
 
     def start(self) -> None:
         """Start a new timer."""
-        # Generate timer init statement for logger.
-        if self.logger:
-            if self.name:
-                text = f"Timer {self.name} started..."
+        if self.logger and self.initial_text:
+            # Generate timer init statement for logger.
+            if isinstance(self.initial_text, str):
+                # To include timer name in text, include {name} within string (not as f-string!).
+                initial_text = self.initial_text.format(name=self.name)
             else:
-                text = "Timer started..."
-            self.logger(text)
+                # If no custom strin is specified print a default statement.
+                initial_text = "Timer started"
+            self.logger(initial_text)
 
         if self._start_time is not None:
             raise TimerError("Timer is running. Use .stop() to stop it")

--- a/codetiming/_timer.py
+++ b/codetiming/_timer.py
@@ -26,28 +26,25 @@ class Timer(ContextDecorator):
     timers: ClassVar[Timers] = Timers()
     _start_time: Optional[float] = field(default=None, init=False, repr=False)
     name: Optional[str] = None
-    initial_text: Optional[Union[bool, str]] = False
     text: Union[str, Callable[[float], str]] = "Elapsed time: {:0.4f} seconds"
+    initial_text: Union[bool, str] = False
     logger: Optional[Callable[[str], None]] = print
     last: float = field(default=math.nan, init=False, repr=False)
 
     def start(self) -> None:
         """Start a new timer."""
-        if self.logger and self.initial_text:
-            # Generate timer init statement for logger.
-            if isinstance(self.initial_text, str):
-                # To include timer name in text, include {name} within string (not as f-string!).
-                initial_text = self.initial_text.format(name=self.name)
-            elif self.name:
-                # If no custom string specified print a default statement using timer name.
-                initial_text = "Timer {name} started".format(name=self.name)
-            else:
-                # If no custom string or timer name is specified print a default statement.
-                initial_text = "Timer started"
-            self.logger(initial_text)
-
         if self._start_time is not None:
             raise TimerError("Timer is running. Use .stop() to stop it")
+
+        # Log initial text when timer starts
+        if self.logger and self.initial_text:
+            if isinstance(self.initial_text, str):
+                initial_text = self.initial_text.format(name=self.name)
+            elif self.name:
+                initial_text = "Timer {name} started".format(name=self.name)
+            else:
+                initial_text = "Timer started"
+            self.logger(initial_text)
 
         self._start_time = time.perf_counter()
 

--- a/codetiming/_timer.py
+++ b/codetiming/_timer.py
@@ -32,6 +32,14 @@ class Timer(ContextDecorator):
 
     def start(self) -> None:
         """Start a new timer."""
+        # Generate timer init statement for logger.
+        if self.logger:
+            if self.name:
+                text = f"Timer {self.name} started..."
+            else:
+                text = "Timer started..."
+            self.logger(text)
+
         if self._start_time is not None:
             raise TimerError("Timer is running. Use .stop() to stop it")
 

--- a/codetiming/_timer.py
+++ b/codetiming/_timer.py
@@ -38,8 +38,11 @@ class Timer(ContextDecorator):
             if isinstance(self.initial_text, str):
                 # To include timer name in text, include {name} within string (not as f-string!).
                 initial_text = self.initial_text.format(name=self.name)
+            elif self.name:
+                # If no custom string specified print a default statement using timer name.
+                initial_text = "Timer {name} started".format(name=self.name)
             else:
-                # If no custom strin is specified print a default statement.
+                # If no custom string or timer name is specified print a default statement.
                 initial_text = "Timer started"
             self.logger(initial_text)
 

--- a/tests/test_codetiming.py
+++ b/tests/test_codetiming.py
@@ -19,34 +19,48 @@ from codetiming import Timer, TimerError
 TIME_PREFIX = "Wasted time:"
 TIME_MESSAGE = f"{TIME_PREFIX} {{:.4f}} seconds"
 RE_TIME_MESSAGE = re.compile(TIME_PREFIX + r" 0\.\d{4} seconds")
+RE_TIME_MESSAGE_INITIAL_TEXT_TRUE = re.compile("Timer started\n" + TIME_PREFIX + r" 0\.\d{4} seconds")
+RE_TIME_MESSAGE_INITIAL_TEXT_CUSTOM = re.compile("Starting the party\n" + TIME_PREFIX + r" 0\.\d{4} seconds")
 
 
 def waste_time(num=1000):
-    """Just waste a little bit of time"""
+    """Just waste a little bit of time."""
     sum(n**2 for n in range(num))
 
 
 @Timer(text=TIME_MESSAGE)
 def decorated_timewaste(num=1000):
-    """Just waste a little bit of time"""
+    """Just waste a little bit of time."""
+    sum(n**2 for n in range(num))
+
+
+@Timer(text=TIME_MESSAGE, initial_text=True)
+def decorated_timewaste_initial_text_true(num=1000):
+    """Just waste a little bit of time."""
+    sum(n**2 for n in range(num))
+
+
+@Timer(text=TIME_MESSAGE, initial_text='Starting the party')
+def decorated_timewaste_initial_text_custom(num=1000):
+    """Just waste a little bit of time."""
     sum(n**2 for n in range(num))
 
 
 @Timer(name="accumulator", text=TIME_MESSAGE)
 def accumulated_timewaste(num=1000):
-    """Just waste a little bit of time"""
+    """Just waste a little bit of time."""
     sum(n**2 for n in range(num))
 
 
 class CustomLogger:
-    """Simple class used to test custom logging capabilities in Timer"""
+    """Simple class used to test custom logging capabilities in Timer."""
 
     def __init__(self):
-        """Store log messages in the .messages attribute"""
+        """Store log messages in the .messages attribute."""
         self.messages = ""
 
     def __call__(self, message):
-        """Add a log message to the .messages attribute"""
+        """Add a log message to the .messages attribute."""
         self.messages += message
 
 
@@ -54,7 +68,7 @@ class CustomLogger:
 # Tests
 #
 def test_timer_as_decorator(capsys):
-    """Test that decorated function prints timing information"""
+    """Test that decorated function prints timing informatio."""
     decorated_timewaste()
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE.match(stdout)
@@ -63,7 +77,7 @@ def test_timer_as_decorator(capsys):
 
 
 def test_timer_as_context_manager(capsys):
-    """Test that timed context prints timing information"""
+    """Test that timed context prints timing information."""
     with Timer(text=TIME_MESSAGE):
         waste_time()
     stdout, stderr = capsys.readouterr()
@@ -73,7 +87,7 @@ def test_timer_as_context_manager(capsys):
 
 
 def test_explicit_timer(capsys):
-    """Test that timed section prints timing information"""
+    """Test that timed section prints timing information."""
     t = Timer(text=TIME_MESSAGE)
     t.start()
     waste_time()
@@ -85,14 +99,14 @@ def test_explicit_timer(capsys):
 
 
 def test_error_if_timer_not_running():
-    """Test that timer raises error if it is stopped before started"""
+    """Test that timer raises error if it is stopped before started."""
     t = Timer(text=TIME_MESSAGE)
     with pytest.raises(TimerError):
         t.stop()
 
 
 def test_access_timer_object_in_context(capsys):
-    """Test that we can access the timer object inside a context"""
+    """Test that we can access the timer object inside a context."""
     with Timer(text=TIME_MESSAGE) as t:
         assert isinstance(t, Timer)
         assert t.text.startswith(TIME_PREFIX)
@@ -100,7 +114,7 @@ def test_access_timer_object_in_context(capsys):
 
 
 def test_custom_logger():
-    """Test that we can use a custom logger"""
+    """Test that we can use a custom logger."""
     logger = CustomLogger()
     with Timer(text=TIME_MESSAGE, logger=logger):
         waste_time()
@@ -108,7 +122,7 @@ def test_custom_logger():
 
 
 def test_timer_without_text(capsys):
-    """Test that timer with logger=None does not print anything"""
+    """Test that timer with logger=None does not print anything."""
     with Timer(logger=None):
         waste_time()
 
@@ -118,7 +132,7 @@ def test_timer_without_text(capsys):
 
 
 def test_accumulated_decorator(capsys):
-    """Test that decorated timer can accumulate"""
+    """Test that decorated timer can accumulate."""
     accumulated_timewaste()
     accumulated_timewaste()
 
@@ -131,7 +145,7 @@ def test_accumulated_decorator(capsys):
 
 
 def test_accumulated_context_manager(capsys):
-    """Test that context manager timer can accumulate"""
+    """Test that context manager timer can accumulate."""
     t = Timer(name="accumulator", text=TIME_MESSAGE)
     with t:
         waste_time()
@@ -147,7 +161,7 @@ def test_accumulated_context_manager(capsys):
 
 
 def test_accumulated_explicit_timer(capsys):
-    """Test that explicit timer can accumulate"""
+    """Test that explicit timer can accumulate."""
     t = Timer(name="accumulated_explicit_timer", text=TIME_MESSAGE)
     total = 0
     t.start()
@@ -167,7 +181,7 @@ def test_accumulated_explicit_timer(capsys):
 
 
 def test_error_if_restarting_running_timer():
-    """Test that restarting a running timer raises an error"""
+    """Test that restarting a running timer raises an error."""
     t = Timer(text=TIME_MESSAGE)
     t.start()
     with pytest.raises(TimerError):
@@ -175,13 +189,13 @@ def test_error_if_restarting_running_timer():
 
 
 def test_last_starts_as_nan():
-    """Test that .last attribute is initialized as nan"""
+    """Test that .last attribute is initialized as nan."""
     t = Timer()
     assert math.isnan(t.last)
 
 
 def test_timer_sets_last():
-    """Test that .last attribute is properly set"""
+    """Test that .last attribute is properly set."""
     with Timer() as t:
         time.sleep(0.02)
 
@@ -189,7 +203,7 @@ def test_timer_sets_last():
 
 
 def test_using_name_in_text_without_explicit_timer(capsys):
-    """Test that the name of the timer can be referenced in the text"""
+    """Test that the name of the timer can be referenced in the text."""
     name = "NamedTimer"
     with Timer(name=name, text="{name}: {:.2f}"):
         waste_time()
@@ -199,7 +213,7 @@ def test_using_name_in_text_without_explicit_timer(capsys):
 
 
 def test_using_name_in_text_with_explicit_timer(capsys):
-    """Test that the name of the timer and the seconds attribute can be referenced in the text"""
+    """Test that the name of the timer and the seconds attribute can be referenced in the text."""
     name = "NamedTimer"
     with Timer(name=name, text="{name}: {seconds:.2f}"):
         waste_time()
@@ -209,7 +223,7 @@ def test_using_name_in_text_with_explicit_timer(capsys):
 
 
 def test_using_minutes_attribute_in_text(capsys):
-    """Test that timer can report its duration in minutes"""
+    """Test that timer can report its duration in minutes."""
     with Timer(text="{minutes:.1f} minutes"):
         waste_time()
 
@@ -218,7 +232,7 @@ def test_using_minutes_attribute_in_text(capsys):
 
 
 def test_using_milliseconds_attribute_in_text(capsys):
-    """Test that timer can report its duration in milliseconds"""
+    """Test that timer can report its duration in milliseconds."""
     with Timer(text="{milliseconds:.0f} {seconds:.3f}"):
         waste_time()
 
@@ -228,7 +242,7 @@ def test_using_milliseconds_attribute_in_text(capsys):
 
 
 def test_text_formatting_function(capsys):
-    """Test that text can be formatted by a separate function"""
+    """Test that text can be formatted by a separate function."""
 
     def format_text(seconds):
         """Function that returns a formatted text"""
@@ -243,10 +257,10 @@ def test_text_formatting_function(capsys):
 
 
 def test_text_formatting_class(capsys):
-    """Test that text can be formatted by a separate class"""
+    """Test that text can be formatted by a separate class."""
 
     class TextFormatter:
-        """Class that behaves like a formatted text"""
+        """Class that behaves like a formatted text."""
 
         def __init__(self, seconds):
             """Initialize with number of seconds"""
@@ -264,7 +278,7 @@ def test_text_formatting_class(capsys):
     assert not stderr.strip()
 
     def format_text(seconds):
-        """Callable that returns a formatted text"""
+        """Callable that returns a formatted text."""
         return f"Callable: {seconds + 1:.0f}"
 
     with Timer(text=format_text):
@@ -276,7 +290,7 @@ def test_text_formatting_class(capsys):
 
 
 def test_timers_cleared():
-    """Test that timers can be cleared"""
+    """Test that timers can be cleared."""
     with Timer(name="timer_to_be_cleared"):
         waste_time()
 
@@ -286,7 +300,7 @@ def test_timers_cleared():
 
 
 def test_running_cleared_timers():
-    """Test that timers can still be run after they're cleared"""
+    """Test that timers can still be run after they're cleared."""
     t = Timer(name="timer_to_be_cleared")
     Timer.timers.clear()
 
@@ -299,7 +313,7 @@ def test_running_cleared_timers():
 
 
 def test_timers_stats():
-    """Test that we can get basic statistics from timers"""
+    """Test that we can get basic statistics from timers."""
     name = "timer_with_stats"
     t = Timer(name=name)
     for num in range(5, 10):
@@ -315,7 +329,7 @@ def test_timers_stats():
 
 
 def test_stats_missing_timers():
-    """Test that getting statistics from non-existent timers raises exception"""
+    """Test that getting statistics from non-existent timers raises exception."""
     with pytest.raises(KeyError):
         Timer.timers.count("non_existent_timer")
 
@@ -324,6 +338,80 @@ def test_stats_missing_timers():
 
 
 def test_setting_timers_exception():
-    """Test that setting .timers items raises exception"""
+    """Test that setting .timers items raises exception."""
     with pytest.raises(TypeError):
         Timer.timers["set_timer"] = 1.23
+
+
+def test_timer_as_decorator_with_initial_text_true(capsys):
+    """Test that decorated function prints timing information with default initial text."""
+    decorated_timewaste_initial_text_true()
+    stdout, stderr = capsys.readouterr()
+    assert RE_TIME_MESSAGE_INITIAL_TEXT_TRUE.match(stdout)
+    assert stdout.count("\n") == 2
+    assert stderr == ""
+
+
+def test_timer_as_context_manager_with_initial_text_true(capsys):
+    """Test that timed context prints timing information with default initial text."""
+    with Timer(text=TIME_MESSAGE, initial_text=True):
+        waste_time()
+    stdout, stderr = capsys.readouterr()
+    assert RE_TIME_MESSAGE_INITIAL_TEXT_TRUE.match(stdout)
+    assert stdout.count("\n") == 2
+    assert stderr == ""
+
+
+def test_explicit_timer_with_initial_text_true(capsys):
+    """Test that timed section prints timing information with default initial text."""
+    t = Timer(text=TIME_MESSAGE, initial_text=True)
+    t.start()
+    waste_time()
+    t.stop()
+    stdout, stderr = capsys.readouterr()
+    assert RE_TIME_MESSAGE_INITIAL_TEXT_TRUE.match(stdout)
+    assert stdout.count("\n") == 2
+    assert stderr == ""
+
+
+def test_timer_as_decorator_with_initial_text_custom(capsys):
+    """Test that decorated function prints timing information with custom initial text."""
+    decorated_timewaste_initial_text_custom()
+    stdout, stderr = capsys.readouterr()
+    assert RE_TIME_MESSAGE_INITIAL_TEXT_CUSTOM.match(stdout)
+    assert stdout.count("\n") == 2
+    assert stderr == ""
+
+
+def test_timer_as_context_manager_with_initial_text_custom(capsys):
+    """Test that timed context prints timing information with custom initial text."""
+    with Timer(text=TIME_MESSAGE, initial_text='Starting the party'):
+        waste_time()
+    stdout, stderr = capsys.readouterr()
+    assert RE_TIME_MESSAGE_INITIAL_TEXT_CUSTOM.match(stdout)
+    assert stdout.count("\n") == 2
+    assert stderr == ""
+
+
+def test_explicit_timer_with_initial_text_custom(capsys):
+    """Test that timed section prints timing information with custom initial text."""
+    t = Timer(text=TIME_MESSAGE, initial_text='Starting the party')
+    t.start()
+    waste_time()
+    t.stop()
+    stdout, stderr = capsys.readouterr()
+    assert RE_TIME_MESSAGE_INITIAL_TEXT_CUSTOM.match(stdout)
+    assert stdout.count("\n") == 2
+    assert stderr == ""
+
+
+def test_explicit_timer_with_initial_text_with_name(capsys):
+    """Test with custom initial text referencing timer name."""
+    t = Timer(name='the party', text=TIME_MESSAGE, initial_text='Starting {name}')
+    t.start()
+    waste_time()
+    t.stop()
+    stdout, stderr = capsys.readouterr()
+    assert RE_TIME_MESSAGE_INITIAL_TEXT_CUSTOM.match(stdout)
+    assert stdout.count("\n") == 2
+    assert stderr == ""

--- a/tests/test_codetiming.py
+++ b/tests/test_codetiming.py
@@ -14,13 +14,17 @@ import pytest
 from codetiming import Timer, TimerError
 
 #
-# Test functions
+# Constants, functions, and classes used by tests
 #
 TIME_PREFIX = "Wasted time:"
 TIME_MESSAGE = f"{TIME_PREFIX} {{:.4f}} seconds"
 RE_TIME_MESSAGE = re.compile(TIME_PREFIX + r" 0\.\d{4} seconds")
-RE_TIME_MESSAGE_INITIAL_TEXT_TRUE = re.compile("Timer started\n" + TIME_PREFIX + r" 0\.\d{4} seconds")
-RE_TIME_MESSAGE_INITIAL_TEXT_CUSTOM = re.compile("Starting the party\n" + TIME_PREFIX + r" 0\.\d{4} seconds")
+RE_TIME_MESSAGE_INITIAL_TEXT_TRUE = re.compile(
+    f"Timer started\n{TIME_PREFIX}" + r" 0\.\d{4} seconds"
+)
+RE_TIME_MESSAGE_INITIAL_TEXT_CUSTOM = re.compile(
+    f"Starting the party\n{TIME_PREFIX}" + r" 0\.\d{4} seconds"
+)
 
 
 def waste_time(num=1000):
@@ -40,7 +44,7 @@ def decorated_timewaste_initial_text_true(num=1000):
     sum(n**2 for n in range(num))
 
 
-@Timer(text=TIME_MESSAGE, initial_text='Starting the party')
+@Timer(text=TIME_MESSAGE, initial_text="Starting the party")
 def decorated_timewaste_initial_text_custom(num=1000):
     """Just waste a little bit of time."""
     sum(n**2 for n in range(num))
@@ -68,8 +72,9 @@ class CustomLogger:
 # Tests
 #
 def test_timer_as_decorator(capsys):
-    """Test that decorated function prints timing informatio."""
+    """Test that decorated function prints timing information."""
     decorated_timewaste()
+
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE.match(stdout)
     assert stdout.count("\n") == 1
@@ -80,6 +85,7 @@ def test_timer_as_context_manager(capsys):
     """Test that timed context prints timing information."""
     with Timer(text=TIME_MESSAGE):
         waste_time()
+
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE.match(stdout)
     assert stdout.count("\n") == 1
@@ -92,6 +98,7 @@ def test_explicit_timer(capsys):
     t.start()
     waste_time()
     t.stop()
+
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE.match(stdout)
     assert stdout.count("\n") == 1
@@ -210,16 +217,18 @@ def test_using_name_in_text_without_explicit_timer(capsys):
 
     stdout, stderr = capsys.readouterr()
     assert re.match(f"{name}: " + r"0\.\d{2}", stdout)
+    assert stderr == ""
 
 
 def test_using_name_in_text_with_explicit_timer(capsys):
-    """Test that the name of the timer and the seconds attribute can be referenced in the text."""
+    """Test that timer name and seconds attribute can be referenced in the text."""
     name = "NamedTimer"
     with Timer(name=name, text="{name}: {seconds:.2f}"):
         waste_time()
 
     stdout, stderr = capsys.readouterr()
     assert re.match(f"{name}: " + r"0\.\d{2}", stdout.strip())
+    assert stderr == ""
 
 
 def test_using_minutes_attribute_in_text(capsys):
@@ -229,6 +238,7 @@ def test_using_minutes_attribute_in_text(capsys):
 
     stdout, stderr = capsys.readouterr()
     assert stdout.strip() == "0.0 minutes"
+    assert stderr == ""
 
 
 def test_using_milliseconds_attribute_in_text(capsys):
@@ -239,6 +249,7 @@ def test_using_milliseconds_attribute_in_text(capsys):
     stdout, stderr = capsys.readouterr()
     milliseconds, _, seconds = stdout.partition(" ")
     assert int(milliseconds) == round(float(seconds) * 1000)
+    assert stderr == ""
 
 
 def test_text_formatting_function(capsys):
@@ -275,17 +286,6 @@ def test_text_formatting_class(capsys):
 
     stdout, stderr = capsys.readouterr()
     assert stdout.strip() == "Class: 1"
-    assert not stderr.strip()
-
-    def format_text(seconds):
-        """Callable that returns a formatted text."""
-        return f"Callable: {seconds + 1:.0f}"
-
-    with Timer(text=format_text):
-        waste_time()
-
-    stdout, stderr = capsys.readouterr()
-    assert stdout.strip() == "Callable: 1"
     assert not stderr.strip()
 
 
@@ -344,8 +344,9 @@ def test_setting_timers_exception():
 
 
 def test_timer_as_decorator_with_initial_text_true(capsys):
-    """Test that decorated function prints timing information with default initial text."""
+    """Test that decorated function prints at start with default initial text."""
     decorated_timewaste_initial_text_true()
+
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE_INITIAL_TEXT_TRUE.match(stdout)
     assert stdout.count("\n") == 2
@@ -353,9 +354,10 @@ def test_timer_as_decorator_with_initial_text_true(capsys):
 
 
 def test_timer_as_context_manager_with_initial_text_true(capsys):
-    """Test that timed context prints timing information with default initial text."""
+    """Test that timed context prints at start with default initial text."""
     with Timer(text=TIME_MESSAGE, initial_text=True):
         waste_time()
+
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE_INITIAL_TEXT_TRUE.match(stdout)
     assert stdout.count("\n") == 2
@@ -363,11 +365,12 @@ def test_timer_as_context_manager_with_initial_text_true(capsys):
 
 
 def test_explicit_timer_with_initial_text_true(capsys):
-    """Test that timed section prints timing information with default initial text."""
+    """Test that timed section prints at start with default initial text."""
     t = Timer(text=TIME_MESSAGE, initial_text=True)
     t.start()
     waste_time()
     t.stop()
+
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE_INITIAL_TEXT_TRUE.match(stdout)
     assert stdout.count("\n") == 2
@@ -375,8 +378,9 @@ def test_explicit_timer_with_initial_text_true(capsys):
 
 
 def test_timer_as_decorator_with_initial_text_custom(capsys):
-    """Test that decorated function prints timing information with custom initial text."""
+    """Test that decorated function prints at start with custom initial text."""
     decorated_timewaste_initial_text_custom()
+
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE_INITIAL_TEXT_CUSTOM.match(stdout)
     assert stdout.count("\n") == 2
@@ -384,9 +388,10 @@ def test_timer_as_decorator_with_initial_text_custom(capsys):
 
 
 def test_timer_as_context_manager_with_initial_text_custom(capsys):
-    """Test that timed context prints timing information with custom initial text."""
-    with Timer(text=TIME_MESSAGE, initial_text='Starting the party'):
+    """Test that timed context prints at start with custom initial text."""
+    with Timer(text=TIME_MESSAGE, initial_text="Starting the party"):
         waste_time()
+
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE_INITIAL_TEXT_CUSTOM.match(stdout)
     assert stdout.count("\n") == 2
@@ -394,11 +399,12 @@ def test_timer_as_context_manager_with_initial_text_custom(capsys):
 
 
 def test_explicit_timer_with_initial_text_custom(capsys):
-    """Test that timed section prints timing information with custom initial text."""
-    t = Timer(text=TIME_MESSAGE, initial_text='Starting the party')
+    """Test that timed section prints at start with custom initial text."""
+    t = Timer(text=TIME_MESSAGE, initial_text="Starting the party")
     t.start()
     waste_time()
     t.stop()
+
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE_INITIAL_TEXT_CUSTOM.match(stdout)
     assert stdout.count("\n") == 2
@@ -407,23 +413,26 @@ def test_explicit_timer_with_initial_text_custom(capsys):
 
 def test_explicit_timer_with_initial_text_true_with_name(capsys):
     """Test with default initial text referencing timer name."""
-    t = Timer(name='named', text=TIME_MESSAGE, initial_text=True)
+    t = Timer(name="named", text=TIME_MESSAGE, initial_text=True)
     t.start()
     waste_time()
     t.stop()
+
     stdout, stderr = capsys.readouterr()
-    assert re.compile("Timer named started\n" + TIME_PREFIX + r" 0\.\d{4} seconds").match(stdout)
+    assert re.match(
+        f"Timer named started\n{TIME_PREFIX}" + r" 0\.\d{4} seconds", stdout
+    )
     assert stdout.count("\n") == 2
     assert stderr == ""
 
 
-
 def test_explicit_timer_with_initial_text_with_name(capsys):
     """Test with custom initial text referencing timer name."""
-    t = Timer(name='the party', text=TIME_MESSAGE, initial_text='Starting {name}')
+    t = Timer(name="the party", text=TIME_MESSAGE, initial_text="Starting {name}")
     t.start()
     waste_time()
     t.stop()
+
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE_INITIAL_TEXT_CUSTOM.match(stdout)
     assert stdout.count("\n") == 2

--- a/tests/test_codetiming.py
+++ b/tests/test_codetiming.py
@@ -18,7 +18,10 @@ from codetiming import Timer, TimerError
 #
 TIME_PREFIX = "Wasted time:"
 TIME_MESSAGE = f"{TIME_PREFIX} {{:.4f}} seconds"
-RE_TIME_MESSAGE = re.compile(TIME_PREFIX + r" 0\.\d{4} seconds")
+RE_TIME_MESSAGE = re.compile("Timer started...\n" + TIME_PREFIX + r" 0\.\d{4} seconds")
+RE_TIME_MESSAGE_ACC = re.compile(
+    "Timer accumulator started...\n" + TIME_PREFIX + r" 0\.\d{4} seconds"
+)
 
 
 def waste_time(num=1000):
@@ -43,11 +46,11 @@ class CustomLogger:
 
     def __init__(self):
         """Store log messages in the .messages attribute"""
-        self.messages = ""
+        self.messages = []
 
     def __call__(self, message):
         """Add a log message to the .messages attribute"""
-        self.messages += message
+        self.messages.append(message)
 
 
 #
@@ -58,7 +61,7 @@ def test_timer_as_decorator(capsys):
     decorated_timewaste()
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE.match(stdout)
-    assert stdout.count("\n") == 1
+    assert stdout.count("\n") == 2
     assert stderr == ""
 
 
@@ -68,7 +71,7 @@ def test_timer_as_context_manager(capsys):
         waste_time()
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE.match(stdout)
-    assert stdout.count("\n") == 1
+    assert stdout.count("\n") == 2
     assert stderr == ""
 
 
@@ -80,7 +83,7 @@ def test_explicit_timer(capsys):
     t.stop()
     stdout, stderr = capsys.readouterr()
     assert RE_TIME_MESSAGE.match(stdout)
-    assert stdout.count("\n") == 1
+    assert stdout.count("\n") == 2
     assert stderr == ""
 
 
@@ -104,7 +107,7 @@ def test_custom_logger():
     logger = CustomLogger()
     with Timer(text=TIME_MESSAGE, logger=logger):
         waste_time()
-    assert RE_TIME_MESSAGE.match(logger.messages)
+    assert RE_TIME_MESSAGE.match("\n".join(logger.messages))
 
 
 def test_timer_without_text(capsys):
@@ -124,9 +127,9 @@ def test_accumulated_decorator(capsys):
 
     stdout, stderr = capsys.readouterr()
     lines = stdout.strip().split("\n")
-    assert len(lines) == 2
-    assert RE_TIME_MESSAGE.match(lines[0])
-    assert RE_TIME_MESSAGE.match(lines[1])
+    assert len(lines) == 4
+    assert RE_TIME_MESSAGE_ACC.match(f"{lines[0]}\n{lines[1]}")
+    assert RE_TIME_MESSAGE_ACC.match(f"{lines[2]}\n{lines[3]}")
     assert stderr == ""
 
 
@@ -140,15 +143,15 @@ def test_accumulated_context_manager(capsys):
 
     stdout, stderr = capsys.readouterr()
     lines = stdout.strip().split("\n")
-    assert len(lines) == 2
-    assert RE_TIME_MESSAGE.match(lines[0])
-    assert RE_TIME_MESSAGE.match(lines[1])
+    assert len(lines) == 4
+    assert RE_TIME_MESSAGE_ACC.match(f"{lines[0]}\n{lines[1]}")
+    assert RE_TIME_MESSAGE_ACC.match(f"{lines[2]}\n{lines[3]}")
     assert stderr == ""
 
 
 def test_accumulated_explicit_timer(capsys):
     """Test that explicit timer can accumulate"""
-    t = Timer(name="accumulated_explicit_timer", text=TIME_MESSAGE)
+    t = Timer(name="accumulator", text=TIME_MESSAGE)
     total = 0
     t.start()
     waste_time()
@@ -159,11 +162,11 @@ def test_accumulated_explicit_timer(capsys):
 
     stdout, stderr = capsys.readouterr()
     lines = stdout.strip().split("\n")
-    assert len(lines) == 2
-    assert RE_TIME_MESSAGE.match(lines[0])
-    assert RE_TIME_MESSAGE.match(lines[1])
+    assert len(lines) == 4
+    assert RE_TIME_MESSAGE_ACC.match(f"{lines[0]}\n{lines[1]}")
+    assert RE_TIME_MESSAGE_ACC.match(f"{lines[2]}\n{lines[3]}")
     assert stderr == ""
-    assert total == Timer.timers["accumulated_explicit_timer"]
+    assert total == Timer.timers["accumulator"]
 
 
 def test_error_if_restarting_running_timer():
@@ -195,7 +198,7 @@ def test_using_name_in_text_without_explicit_timer(capsys):
         waste_time()
 
     stdout, stderr = capsys.readouterr()
-    assert re.match(f"{name}: " + r"0\.\d{2}", stdout)
+    assert re.match(f"Timer {name} started...\n{name}: " + r"0\.\d{2}", stdout)
 
 
 def test_using_name_in_text_with_explicit_timer(capsys):
@@ -205,7 +208,7 @@ def test_using_name_in_text_with_explicit_timer(capsys):
         waste_time()
 
     stdout, stderr = capsys.readouterr()
-    assert re.match(f"{name}: " + r"0\.\d{2}", stdout.strip())
+    assert re.match(f"Timer {name} started...\n{name}: " + r"0\.\d{2}", stdout.strip())
 
 
 def test_using_minutes_attribute_in_text(capsys):
@@ -214,7 +217,8 @@ def test_using_minutes_attribute_in_text(capsys):
         waste_time()
 
     stdout, stderr = capsys.readouterr()
-    assert stdout.strip() == "0.0 minutes"
+    stdout_start, stdout_stop = stdout.strip().split("\n")
+    assert stdout_stop.strip() == "0.0 minutes"
 
 
 def test_using_milliseconds_attribute_in_text(capsys):
@@ -223,7 +227,8 @@ def test_using_milliseconds_attribute_in_text(capsys):
         waste_time()
 
     stdout, stderr = capsys.readouterr()
-    milliseconds, _, seconds = stdout.partition(" ")
+    stdout_start, stdout_stop = stdout.strip().split("\n")
+    milliseconds, _, seconds = stdout_stop.partition(" ")
     assert int(milliseconds) == round(float(seconds) * 1000)
 
 
@@ -238,7 +243,8 @@ def test_text_formatting_function(capsys):
         waste_time()
 
     stdout, stderr = capsys.readouterr()
-    assert stdout.strip() == "Function: 1"
+    stdout_start, stdout_stop = stdout.strip().split("\n")
+    assert stdout_stop.strip() == "Function: 1"
     assert not stderr.strip()
 
 
@@ -260,7 +266,8 @@ def test_text_formatting_class(capsys):
         waste_time()
 
     stdout, stderr = capsys.readouterr()
-    assert stdout.strip() == "Class: 1"
+    stdout_start, stdout_stop = stdout.strip().split("\n")
+    assert stdout_stop.strip() == "Class: 1"
     assert not stderr.strip()
 
     def format_text(seconds):
@@ -271,7 +278,8 @@ def test_text_formatting_class(capsys):
         waste_time()
 
     stdout, stderr = capsys.readouterr()
-    assert stdout.strip() == "Callable: 1"
+    stdout_start, stdout_stop = stdout.strip().split("\n")
+    assert stdout_stop.strip() == "Callable: 1"
     assert not stderr.strip()
 
 

--- a/tests/test_codetiming.py
+++ b/tests/test_codetiming.py
@@ -405,6 +405,19 @@ def test_explicit_timer_with_initial_text_custom(capsys):
     assert stderr == ""
 
 
+def test_explicit_timer_with_initial_text_true_with_name(capsys):
+    """Test with default initial text referencing timer name."""
+    t = Timer(name='named', text=TIME_MESSAGE, initial_text=True)
+    t.start()
+    waste_time()
+    t.stop()
+    stdout, stderr = capsys.readouterr()
+    assert re.compile("Timer named started\n" + TIME_PREFIX + r" 0\.\d{4} seconds").match(stdout)
+    assert stdout.count("\n") == 2
+    assert stderr == ""
+
+
+
 def test_explicit_timer_with_initial_text_with_name(capsys):
     """Test with custom initial text referencing timer name."""
     t = Timer(name='the party', text=TIME_MESSAGE, initial_text='Starting {name}')


### PR DESCRIPTION
When using the timer I always put an additional log statement when instantiating the timer to provide feedback that the timer has begun (in my particular case it's to provide feedback to users that the stage in the script is running instead of staring at a screen for several minutes to see the final stop timer logging statement).

With that in mind I'm opening this PR to see if this is a feature(?) that people think would be worthwhile folding into the `codetiming` package proper.

The example output with the changes implemented would be
```python
>>> t = Timer()
>>> t.start()
>>> time.sleep(5)
>>> t.stop()

Timer started...
Elapsed time: 5.0015 seconds

>>> with Timer(name="context manager"):
>>>     time.sleep(5)

Timer context manager started...
Elapsed time: 5.0028 seconds

>>> @Timer(name="decorator")
>>> def stuff():
>>>     time.sleep(5)
>>> stuff()

Timer decorator started...
Elapsed time: 5.0025 seconds


>>> import logging
>>> logging.basicConfig(
>>>     level=logging.INFO,
>>>     format='%(asctime)s %(levelname)s %(name)s: %(message)s',
>>> )
>>> logger = logging.getLogger(__name__)
>>> t = Timer(logger=logger.info)
>>> t.start()
>>> time.sleep(5)
>>> t.stop()

2022-11-06 21:13:13,174 INFO __main__: Timer started...
2022-11-06 21:13:18,176 INFO __main__: Elapsed time: 5.0014 seconds
```

I am in no way tied to the string I've chosen for printing when a timer in instantiated, so if people had a preferred statement I can swap it out.

I've updated all the tests to handle the change with the exception of `test_accumulated_explicit_timer`, which fails due to the two timers in the test no longer having the same total time recorded (e.g. `assert 0.0006444760000000049 == 0.0020246230000000587` as an output for the failing test). I'm at a bit of a loss on how to reconcile this particular test so would appreciate some guidance here also if the PR is to precede.